### PR TITLE
Upgrade crux to 1.17.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/test.check "1.1.0"]
                  [juxt/crux-core "21.05-1.17.0-beta"]
                  [juxt/crux-jdbc "21.05-1.17.0-beta"]
                  [yogthos/config "1.1.5"]]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [juxt/crux-core "20.12-1.13.0-beta"]
-                 [juxt/crux-jdbc "20.12-1.13.0-beta"]
+                 [juxt/crux-core "21.05-1.17.0-beta"]
+                 [juxt/crux-jdbc "21.05-1.17.0-beta"]
                  [yogthos/config "1.1.5"]]
   :repl-options {:init-ns common.crux-svc})

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -67,14 +67,13 @@
   [node ids]
   {:pre [(vector? ids)]}
   (->> (crux/q (crux/db node)
-               `{:find [~'?e]
+               `{:find [~'(pull ?e [*])]
                  :where [[~'?e :crux.db/id ~'?id]]
                  :args ~(reduce
                          (fn [q id]
                            (conj q {'?id id}))
                          []
-                         ids)
-                 :full-results? true})
+                         ids)})
        (map first)))
 
 (defn find-entities-by-ids-and-type

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -49,10 +49,9 @@
 (defn find-entity-by-id
   [node id]
   (->> (crux/q (crux/db node)
-               {:find '[?e]
+               {:find '[(pull ?e [*])]
                 :where '[[?e :crux.db/id ?id]]
-                :args [{'?id id}]
-                :full-results? true})
+                :args [{'?id id}]})
        (ffirst)))
 
 (defn find-entity-by-id-and-type

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -94,11 +94,10 @@
 (defn find-entities-by-attr
   [node entity-type attr value]
   (->> (crux/q (crux/db node)
-               {:find '[?e]
+               {:find '[(pull ?e [*])]
                 :where [['?e attr '?v]
                         ['?e :entity/type '?t]]
-                :args [{'?v value '?t entity-type}]
-                :full-results? true})
+                :args [{'?v value '?t entity-type}]})
        (map first)))
 
 (defn find-entities-by-attrs

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -57,11 +57,10 @@
 (defn find-entity-by-id-and-type
   [node id entity-type]
   (->> (crux/q (crux/db node)
-               {:find '[?e]
+               {:find '[(pull ?e [*])]
                 :where '[[?e :crux.db/id ?id]
                          [?e :entity/type ?t]]
-                :args [{'?id id '?t entity-type}]
-                :full-results? true})
+                :args [{'?id id '?t entity-type}]})
        (ffirst)))
 
 (defn find-entities-by-ids

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -190,7 +190,7 @@
                              (cond-> q
                                (some? v)
                                (conj (get symm a))))
-                           ['?e]
+                           '[(pull ?e [*])]
                            predicates)
             :where ~(reduce (fn [q [a v]]
                               (let [ffn (:first v)
@@ -226,7 +226,7 @@
                                     {'?t entity-type}
                                     avs)
                             predicates)]
-            :full-results? true})
+            })
          (map first))))
 
 (defn find-entity-by-attr

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -81,15 +81,14 @@
   {:pre [(vector? ids)]}
   (let [tids (mapv #(vector entity-type %) ids)]
     (->> (crux/q (crux/db node)
-                 `{:find [~'?e]
+                 `{:find [~'(pull ?e [*])]
                    :where [[~'?e :entity/type ~'?t]
                            [~'?e :crux.db/id ~'?id]]
                    :args ~(reduce
                            (fn [q id]
                              (conj q {'?t entity-type '?id id}))
                            []
-                           ids)
-                   :full-results? true})
+                           ids)})
          (map first))))
 
 (defn find-entities-by-attr

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -282,10 +282,9 @@
 (defn entities
   [node entity-type]
   (->> (crux/q (crux/db node)
-               {:find '[?e]
+               {:find '[(pull ?e [*])]
                 :where '[[?e :entity/type ?t]]
-                :args [{'?t entity-type}]
-                :full-results? true})
+                :args [{'?t entity-type}]})
        (map first)))
 
 (defn retrieve-entity-tx-by-id

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -134,7 +134,7 @@
                              (cond-> q
                                (some? v)
                                (conj (get symm a))))
-                           ['?e]
+                           '[(pull ?e [*])]
                            order-by)
             :where ~(reduce (fn [q [a v]]
                               (cond-> q
@@ -171,7 +171,7 @@
                                     {'?t entity-type}
                                     avs)
                             order-by)]
-            :full-results? true})
+            })
          (map first))))
 
 (defn find-entities-by-attrs-with-predicates-and-limit

--- a/src/common/crux_svc.clj
+++ b/src/common/crux_svc.clj
@@ -105,7 +105,7 @@
   {:pre [(map? attrs)]}
   (let [syma (into {} (for [[k v] attrs] [k (gen-sym k)]))]
     (->> (crux/q (crux/db node)
-                 `{:find [~'?e]
+                 `{:find [~'(pull ?e [*])]
                    :where ~(reduce
                             (fn [q [a v]]
                               (conj q ['?e a (get syma a)]))
@@ -115,8 +115,7 @@
                             (fn [q [a v]]
                               (assoc q (get syma a) v))
                             {'?t entity-type}
-                            attrs)]
-                   :full-results? true})
+                            attrs)]})
          (map first))))
 
 (defn find-entities-by-attrs-with-order-by-and-limit

--- a/test/common/crux_svc_test.clj
+++ b/test/common/crux_svc_test.clj
@@ -129,3 +129,16 @@
       (is (= 1 (count find-one-entity)))
       (is (= (first ids) (:crux.db/id (first find-one-entity))))
       (is (= 10 (count find-all-entities))))))
+
+
+(deftest test-find-entities-by-ids-and-type
+  (testing "Find Entities by ids and type"
+    (let [entities (->> (range 10)
+                        (map #(create-entity-sync node entity-type {:name (format "test find-entities-by-ids-and-type %s" %)})))
+          ids (->> (map :crux.db/id entities)
+                   (into []))
+          find-one-entity (find-entities-by-ids-and-type node [(first ids)] entity-type)
+          find-all-entities (find-entities-by-ids-and-type node ids entity-type)]
+      (is (= 1 (count find-one-entity)))
+      (is (= (first ids) (:crux.db/id (first find-one-entity))))
+      (is (= 10 (count find-all-entities))))))

--- a/test/common/crux_svc_test.clj
+++ b/test/common/crux_svc_test.clj
@@ -142,3 +142,14 @@
       (is (= 1 (count find-one-entity)))
       (is (= (first ids) (:crux.db/id (first find-one-entity))))
       (is (= 10 (count find-all-entities))))))
+
+
+(deftest test-find-entities-by-attrs-with-order-by-and-limit
+  (testing "Find Entities by attrs with order by and limit"
+    (let [entities (->> (range 10)
+                        (map #(create-entity-sync node entity-type {:name "test find-entities-by-attrs-with-order-by-and-limit"
+                                                                    :order %})))
+          find-all-entities (find-entities-by-attrs-with-order-by-and-limit node entity-type {:name "test find-entities-by-attrs-with-order-by-and-limit"} {:order :desc-rev} 100)]
+      (is (= 9 (->> (first find-all-entities)
+                    (:order))))
+      (is (= 10 (count find-all-entities))))))

--- a/test/common/crux_svc_test.clj
+++ b/test/common/crux_svc_test.clj
@@ -153,3 +153,5 @@
       (is (= 9 (->> (first find-all-entities)
                     (:order))))
       (is (= 10 (count find-all-entities))))))
+
+;; TODO test find-entities-by-attrs-with-predicates-and-limit

--- a/test/common/crux_svc_test.clj
+++ b/test/common/crux_svc_test.clj
@@ -118,3 +118,14 @@
 (deftest test-find-entities-by-attr
   (testing "Find entities by attr"
     (tc/quick-check 100 prop-find-entities-by-attrs)))
+(deftest test-find-entities-by-ids
+  (testing "Find Entities by ids"
+    (let [entities (->> (range 10)
+                        (map #(create-entity-sync node entity-type {:name (format "test find-entities-by-ids %s" %)})))
+          ids (->> (map :crux.db/id entities)
+                   (into []))
+          find-one-entity (find-entities-by-ids node [(first ids)])
+          find-all-entities (find-entities-by-ids node ids)]
+      (is (= 1 (count find-one-entity)))
+      (is (= (first ids) (:crux.db/id (first find-one-entity))))
+      (is (= 10 (count find-all-entities))))))


### PR DESCRIPTION
breaking changes from crux:
1. the removal of the previously deprecated :full-results? flag:
```clj
{:find [e]
 :where [...]
 :full-results? true}

;; =>

{:find [(pull e [*])]
 :where [...]}
```

2. JDBC - Required migration
In PostgreSQL, DROP INDEX tx_events_event_key_idx; CREATE INDEX CONCURRENTLY tx_events_event_key_idx_2 ON tx_events(event_key);
more details on https://github.com/juxt/crux/releases/tag/21.05-1.17.0

I also added [org.clojure/test.check "1.1.0"], otherwise it will throw 
`java.io.FileNotFoundException: Could not locate clojure/test/check__init.class, clojure/test/check.clj or clojure/test/check.cljc on classpath.`
when `lein test :only common.crux-svc-test` on 715cf41ceb70432621d307be63da7569cf1115bd